### PR TITLE
Feature: expose request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const opaClient = new OpenPolicyAgentClient({
   cache?: Cache // optional
   opaVersion?: string // defaults to 'v1'
   method?: 'POST' | 'GET' // defaults to 'POST'
+  requestOptions?: UndiciRequestOptions // among other things, allows setting a proxy
 })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@treedom/opa-client-sdk",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@treedom/opa-client-sdk",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "object-hash": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treedom/opa-client-sdk",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "An undici-based client for Open Policy Agent",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/lib/OpenPolicyAgentClient.ts
+++ b/src/lib/OpenPolicyAgentClient.ts
@@ -7,11 +7,14 @@ import { OpaClientServerError } from './errors/opaClientServerError'
 import { OpaClientNotFoundError } from './errors/opaClientNotFoundError'
 import { OpaClientUnknownError } from './errors/opaClientUnknownError'
 
+export type UndiciRequestOptions = Parameters<typeof request>[1]
+
 export type OpenPolicyAgentClientProps<TCache extends Cache> = {
   url: string
   opaVersion?: string
   method?: 'POST' | 'GET'
   cache?: TCache
+  requestOptions?: UndiciRequestOptions
 }
 
 type BadRequestBody = {
@@ -24,6 +27,7 @@ type BadRequestBody = {
 export class OpenPolicyAgentClient<TCache extends Cache> {
   public readonly cache: TCache | undefined
   private readonly url: string
+  private readonly requestOptions: UndiciRequestOptions
 
   constructor(
     config: OpenPolicyAgentClientProps<TCache> | string,
@@ -44,6 +48,10 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
 
       if (config.cache) {
         this.cache = config.cache
+      }
+
+      if (config.requestOptions) {
+        this.requestOptions = config.requestOptions
       }
     } else {
       this.url = config
@@ -74,6 +82,7 @@ export class OpenPolicyAgentClient<TCache extends Cache> {
     const res = await request(
       `${this.url}/${this.opaVersion}/data/${resourcePath}`,
       {
+        ...this.requestOptions,
         method: this.method,
         body: input ? JSON.stringify({ input }) : undefined,
       }


### PR DESCRIPTION
Allows users to pass additional options to the underneath HTTP requests, most notably, allows the use of a proxy.